### PR TITLE
add callout format

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 > # What is this lesson about?
 >
 > Welcome. In this lesson you will learn about the CMS detector and how it works.
-
+{: .callout}
 
 > ## Prerequisites
 >


### PR DESCRIPTION
Lesson title page had a segment that I think would look nicer with the carpentries {: .callout} below it. 